### PR TITLE
AppVeyor: parallelize without running out of memory

### DIFF
--- a/build.bat
+++ b/build.bat
@@ -454,6 +454,24 @@ SET MSBUILD_LOGS=/fl1 /fl2 /fl3 ^
 /flp2:warningsonly;Verbosity=Diagnostic;logfile=msbuild-warnings.txt;Append;Encoding=UTF-8 ^
 /flp3:errorsonly;Verbosity=Diagnostic;logfile=msbuild-errors.txt;Append;Encoding=UTF-8
 
+SET MSBUILD_COMMON=^
+/nologo ^
+/toolsversion:%TOOLS_VERSION% ^
+/p:Configuration=%BUILD_TYPE% ^
+/p:Platform=%BUILDPLATFORM% ^
+/p:StopOnFirstFailure=true ^
+%MSBUILD_VERBOSITY% %MSBUILD_LOGS%
+
+SET MSBUILD_PARALLEL=/maxcpucount:1
+IF %NUMBER_OF_PROCESSORS% GEQ 4 SET MSBUILD_PARALLEL=/p:BuildInParallel=true /maxcpucount:2
+IF %NUMBER_OF_PROCESSORS% GEQ 8 SET MSBUILD_PARALLEL=/p:BuildInParallel=true /maxcpucount:3
+:: since any CL.EXE /MP is able to use all available processors (provided it is given enough
+:: sources to compile), using multiple MSBUILD workers only makes sense when you have more
+:: processors than sources per directory (because sources from different directories yield
+:: different /Fo paths, a separate CL.EXE /MP master process must be run for each directory)
+
+IF DEFINED APPVEYOR SET MSBUILD_PARALLEL=/maxcpucount:1
+
 ::build heavy files single threaded
 
 ::MAYBE TRY SINGLE FILES MULTITHREADED????
@@ -494,19 +512,23 @@ GOTO CURRENT
 
 :CURRENT
 
+SET HEAVY_SOURCES=^
+..\..\src\renderer_common\render_group_symbolizer.cpp;^
+..\..\src\renderer_common\render_markers_symbolizer.cpp;^
+..\..\src\renderer_common\render_thunk_extractor.cpp;^
+..\..\src\css_color_grammar.cpp;^
+..\..\src\expression_grammar.cpp;^
+..\..\src\image_filter_grammar.cpp;^
+..\..\src\transform_expression_grammar.cpp
 
 ECHO building heavy files first...
+IF DEFINED APPVEYOR (ECHO disabling parallel compilation && SET _CL_=/MP1)
 msbuild ^
 .\build\mapnik.vcxproj ^
 /t:ClCompile ^
-/p:SelectedFiles="..\..\src\css_color_grammar.cpp;..\..\src\expression_grammar.cpp;..\..\src\transform_expression_grammar.cpp;..\..\src\image_filter_grammar.cpp;..\..\src\agg\process_markers_symbolizer.cpp;..\..\src\agg\process_group_symbolizer.cpp;..\..\src\grid\process_markers_symbolizer.cpp;..\..\src\grid\process_group_symbolizer.cpp;..\..\src\cairo\process_markers_symbolizer.cpp;..\..\src\cairo\process_group_symbolizer.cpp;..\src\renderer_common\process_group_symbolizer.cpp" ^
-/nologo ^
-/m:1 ^
-/toolsversion:%TOOLS_VERSION% ^
-/p:BuildInParallel=false ^
-/p:Configuration=%BUILD_TYPE% ^
-/p:StopOnFirstFailure=true ^
-/p:Platform=%BUILDPLATFORM% %MSBUILD_VERBOSITY% %MSBUILD_LOGS%
+/p:SelectedFiles="%HEAVY_SOURCES%" ^
+%MSBUILD_COMMON%
+
 ECHO msbuild ERRORLEVEL^: %ERRORLEVEL%
 IF %ERRORLEVEL% NEQ 0 (ECHO error during build && GOTO ERROR) ELSE (ECHO build finished)
 
@@ -516,31 +538,14 @@ IF %ERRORLEVEL% NEQ 0 (ECHO error during build && GOTO ERROR) ELSE (ECHO build f
 
 
 
-::build heavy projects single threaded
-ECHO calling msbuild on mapnik-json and mapnik-wkt...
-msbuild ^
-.\build\mapnik.sln ^
-/t:mapnik-json;mapnik-wkt ^
-/nologo ^
-/m:%NUMBER_OF_PROCESSORS% ^
-/toolsversion:%TOOLS_VERSION% ^
-/p:BuildInParallel=true ^
-/p:Configuration=%BUILD_TYPE% ^
-/p:StopOnFirstFailure=true ^
-/p:Platform=%BUILDPLATFORM% %MSBUILD_VERBOSITY% %MSBUILD_LOGS%
-ECHO msbuild ERRORLEVEL^: %ERRORLEVEL%
-IF %ERRORLEVEL% NEQ 0 (ECHO error during build && GOTO ERROR) ELSE (ECHO build finished)
-
-::GOTO DONE
-
-
-
 ::build everything else
 ::on AppVeyor just the mapnik project
 
+SET MAPNIK_LIBS=mapnik;mapnik-json;mapnik-wkt
+SET MAPNIK_PLUGINS=csv;gdal;geojson;ogr;pgraster;postgis;raster;shape;sqlite;topojson
 SET MAPNIK_PROJECT=
 IF DEFINED LOCAL_BUILD_DONT_SKIP_TESTS GOTO DO_MAPNIK_BUILD
-IF DEFINED APPVEYOR SET MAPNIK_PROJECT=/t:mapnik;csv;gdal;geojson;ogr;pgraster;postgis;raster;shape;sqlite;topojson
+IF DEFINED APPVEYOR SET MAPNIK_PROJECT=/t:%MAPNIK_LIBS%;%MAPNIK_PLUGINS%
 
 :DO_MAPNIK_BUILD
 
@@ -550,17 +555,13 @@ IF %RUNCODEANALYSIS% EQU 1 DEL /S *.lastcodeanalysissucceeded && ECHO deleting p
 IF %ERRORLEVEL% NEQ 0 (ECHO could not delete previous analysis results && GOTO ERROR) ELSE (ECHO previous analysis results deleted)
 
 IF DEFINED APPVEYOR (ECHO calling msbuild on %MAPNIK_PROJECT%) ELSE (ECHO calling msbuild on whole mapnik solution...)
+IF DEFINED APPVEYOR (ECHO enabling parallel compilation && SET _CL_=)
 msbuild ^
 .\build\mapnik.sln %MAPNIK_PROJECT% ^
-/nologo ^
-/m:%NUMBER_OF_PROCESSORS% ^
-/toolsversion:%TOOLS_VERSION% ^
-/p:BuildInParallel=true ^
-/p:Configuration=%BUILD_TYPE% ^
-/p:StopOnFirstFailure=true ^
-/p:Platform=%BUILDPLATFORM% %ANALYZE_MAPNIK% %MSBUILD_VERBOSITY% %MSBUILD_LOGS%
+%MSBUILD_COMMON% %MSBUILD_PARALLEL% %ANALYZE_MAPNIK%
 :: /t:rebuild
 :: /v:diag > build.log
+
 ECHO msbuild ERRORLEVEL^: %ERRORLEVEL%
 IF %ERRORLEVEL% NEQ 0 (ECHO error during build && GOTO ERROR) ELSE (ECHO build finished)
 

--- a/build.bat
+++ b/build.bat
@@ -417,15 +417,6 @@ ECHO label DOFASTBUILD
 
 ECHO INCLUDE %INCLUDE%
 
-IF NOT DEFINED APPVEYOR GOTO GENERATE_SOLUTION
-ECHO on AppVeyor && ECHO using common.gypi without optimizations
-IF EXIST common.gypi-optimized ECHO deleting existing common.gypi-optimized && DEL common.gypi-optimized
-ECHO renaming existing common.gypi to common.gypi-optimized && IF EXIST common.gypi REN common.gypi common.gypi-optimized
-IF %ERRORLEVEL% NEQ 0 GOTO ERROR
-ECHO copying common.gypi-appveyor to common.gypi
-COPY common.gypi-appveyor common.gypi
-IF %ERRORLEVEL% NEQ 0 GOTO ERROR
-
 :GENERATE_SOLUTION
 
 ::generate a debug version of the gyp file: -f gypd -DOS=win
@@ -445,12 +436,6 @@ CALL gyp\gyp.bat mapnik.gyp --depth=. ^
  --generator-output=build
 ECHO ERRORLEVEL^: %ERRORLEVEL%
 IF %ERRORLEVEL% NEQ 0 (ECHO error during solution file generation && GOTO ERROR) ELSE (ECHO solution file generated)
-
-::for local development simulating AppVeyor, copy back common.gypi
-IF EXIST common.gypi-optimized ECHO deleting common.gypi && DEL common.gypi
-IF %ERRORLEVEL% NEQ 0 GOTO ERROR
-IF EXIST common.gypi-optimized ECHO renaming common.gypi-optimized to common.gypi && REN common.gypi-optimized common.gypi
-IF %ERRORLEVEL% NEQ 0 GOTO ERROR
 
 ::verbosity: q[uiet], m[inimal], n[ormal], d[etailed], and diag[nostic]
 SET MSBUILD_VERBOSITY=

--- a/common.gypi
+++ b/common.gypi
@@ -85,7 +85,6 @@
             "EnableIntrinsicFunctions": "true",
             "MultiProcessorCompilation": "true",
             "AdditionalOptions": [
-              #"/MP", # compile across multiple CPUs
               "/bigobj", #compiling: x86 fatal error C1128: number of sections exceeded object file format limit: compile with /bigobj
             ],
             "DebugInformationFormat": "3"

--- a/common.gypi-appveyor
+++ b/common.gypi-appveyor
@@ -87,7 +87,6 @@
             "DebugInformationFormat": "0", #0:disable 1:/Z7 3:/Zi 4:/ZI , see GenerateDebugInformation below, https://msdn.microsoft.com/en-us/library/958x11bc.aspx
             "MultiProcessorCompilation": "true",
             "AdditionalOptions": [
-              #"/MP", # compile across multiple CPUs
               "/bigobj", #compiling: x86 fatal error C1128: number of sections exceeded object file format limit: compile with /bigobj
               #"/Zm200", #prevent: Fatal Error C1060 compiler is out of heap space
             ],

--- a/mapnik.gyp
+++ b/mapnik.gyp
@@ -798,6 +798,11 @@
     }
   ],
   "conditions": [
+    ["buildbot == 'appveyor'",
+      {
+        "includes": [ "./common.gypi-appveyor" ]
+      }
+    ],
     ["OS=='win'", {
       "targets": [
         {

--- a/mapnik.gyp
+++ b/mapnik.gyp
@@ -7,6 +7,7 @@
     "libs%":"",
     "configuration%":"",
     "platform%":"",
+    "buildbot%":"",
     "common_defines": [
       "WIN32_LEAN_AND_MEAN",
       "BIGINT",
@@ -41,6 +42,11 @@
       ["OS=='win'",
         {
           "conditions": [
+            ["'<!(IF DEFINED APPVEYOR ECHO %APPVEYOR%)' == 'True'",
+              {
+                  "buildbot":"appveyor"
+              }
+            ],
             ["configuration=='Debug'",
               {
                   "boost_filesystem_lib":"libboost_filesystem-<(boost_toolset)-mt-gd-<(boost_version).lib",
@@ -119,6 +125,19 @@
       ],
       "include_dirs":[
         "<@(common_includes)"
+      ],
+      "conditions": [
+        ["buildbot == 'appveyor'",
+          {
+            "msvs_settings": {
+              "VCCLCompilerTool": {
+                "AdditionalOptions": [
+                  "/MP1", # limit parallel compilation of memory-intensive sources
+                ]
+              }
+            }
+          }
+        ]
       ]
     },
     {
@@ -132,6 +151,19 @@
       ],
       "include_dirs":[
         "<@(common_includes)"
+      ],
+      "conditions": [
+        ["buildbot == 'appveyor'",
+          {
+            "msvs_settings": {
+              "VCCLCompilerTool": {
+                "AdditionalOptions": [
+                  "/MP1", # limit parallel compilation of memory-intensive sources
+                ]
+              }
+            }
+          }
+        ]
       ]
     },
     {
@@ -337,6 +369,17 @@
               "<(icuuc_lib)",
             ]
           }
+        ],
+        ["buildbot == 'appveyor'",
+          {
+            "msvs_settings": {
+              "VCCLCompilerTool": {
+                "AdditionalOptions": [
+                  "/MP2", # limit parallel compilation of memory-intensive sources
+                ]
+              }
+            }
+          }
         ]
       ]
     },
@@ -354,6 +397,17 @@
             "libraries": [
               "<(icuuc_lib)",
             ]
+          }
+        ],
+        ["buildbot == 'appveyor'",
+          {
+            "msvs_settings": {
+              "VCCLCompilerTool": {
+                "AdditionalOptions": [
+                  "/MP2", # limit parallel compilation of memory-intensive sources
+                ]
+              }
+            }
           }
         ]
       ]
@@ -392,6 +446,17 @@
               "<(icuuc_lib)",
               "harfbuzz.lib"
             ],
+          }
+        ],
+        ["buildbot == 'appveyor'",
+          {
+            "msvs_settings": {
+              "VCCLCompilerTool": {
+                "AdditionalOptions": [
+                  "/MP2", # limit parallel compilation of memory-intensive sources
+                ]
+              }
+            }
           }
         ]
       ]


### PR DESCRIPTION
In short: run only 1 MSBUILD process, allow CL to use all processors, except on heavy sources where it's restricted to 1 (or 2 for heavier plugins)

It's possible to finish in 16 minutes: https://ci.appveyor.com/project/Mapbox/mapnik/history?branch=wip-msbuild-parallel
