### PR TITLE
disable warning C4348: redefinition of default parameter

### DIFF
--- a/common.gypi
+++ b/common.gypi
@@ -9,7 +9,8 @@
       4244, # should consider re-enabling now after https://github.com/mapnik/mapnik/issues/2907 (conversion from 'type1' to 'type2', possible loss of data)
       4005, # 'identifier' : macro redefinition
       4506, # no definition for inline function 'function'
-      4661,  # no suitable definition provided for explicit template instantiation request
+      4661, # no suitable definition provided for explicit template instantiation request
+      4348, # redefinition of default parameter (pouring from boost::spirit::terminal)
       4503 # name length exceeded, name was truncated (not a problem, let's ignore)
     ],
     "msvs_settings": {

--- a/common.gypi-appveyor
+++ b/common.gypi-appveyor
@@ -9,7 +9,8 @@
       4244, # should consider re-enabling now after https://github.com/mapnik/mapnik/issues/2907 (conversion from 'type1' to 'type2', possible loss of data)
       4005, # 'identifier' : macro redefinition
       4506, # no definition for inline function 'function'
-      4661  # no suitable definition provided for explicit template instantiation request
+      4661, # no suitable definition provided for explicit template instantiation request
+      4348, # redefinition of default parameter (pouring from boost::spirit::terminal)
     ],
     "msvs_settings": {
       "VCCLCompilerTool": {


### PR DESCRIPTION
https://msdn.microsoft.com/en-us/library/kxef26tw.aspx

It's coming in thousands from `<boost/spirit/home/support/terminal.hpp>` and I think it's spurious; the template it reports is only defined once with default parameters.